### PR TITLE
Bugfix for missing columns

### DIFF
--- a/UFC_Final_Project.ipynb
+++ b/UFC_Final_Project.ipynb
@@ -167,6 +167,7 @@
     "    \"B_Losses\",\n",
     "    \"B_Draws\",\n",
     "    \"B_No_Contest\",\n",
+    "    \"B_Career_Significant_Strikes_Absorbed_PM\",\n",
     "    \"B_Career_Significant_Strikes_Landed_PM\",\n",
     "    \"B_Career_Striking_Accuracy\",\n",
     "    \"B_Career_Significant_Strike_Defence\",\n",
@@ -328,6 +329,7 @@
     "    \"R_Losses\",\n",
     "    \"R_Draws\",\n",
     "    \"R_No_Contest\",\n",
+    "    \"R_Career_Significant_Strikes_Absorbed_PM\",\n",
     "    \"R_Career_Significant_Strikes_Landed_PM\",\n",
     "    \"R_Career_Striking_Accuracy\",\n",
     "    \"R_Career_Significant_Strike_Defence\",\n",
@@ -479,7 +481,21 @@
     "    \"R_Round_Five_Submission_Attempts\",\n",
     "    \"R_Round_Five_Grappling_Reversals\",\n",
     "    \"R_Round_Five_Grappling_Control_Time\",\n",
-    "]\n"
+    "]\n",
+    "\n",
+    "# TODO: Should we alphabetize sort the columns instead of hardcoding?\n",
+    "# np.sort(ufc_df.columns.tolist())\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8606f119",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Symmetric difference between old & new columns to ensure columns are not missing.\n",
+    "set(ufc_df.columns.tolist()) ^ set(new_column_order)\n"
    ]
   },
   {


### PR DESCRIPTION
## Description
The columns `B_Career_Significant_Strikes_Absorbed_PM` & `R_Career_Significant_Strikes_Absorbed_PM` were not added to the re-ordered list and were being dropped.

## How Has This Been Tested?
- Using the symmetric difference between original & re-ordered columns
- Comparing the length of the column list between original & re-ordered columns
## Screenshots
![column_difference](https://user-images.githubusercontent.com/40713017/160265381-417daa17-830a-4ef5-a6c8-1aa925b00cdd.PNG)

