### PR TITLE
Enhancements for pie chart queries 

### DIFF
--- a/streamlit/main.py
+++ b/streamlit/main.py
@@ -252,13 +252,7 @@ elif data_selection == "Create your own fighter":
     # TODO: Display statistics of selected fighter.
 
 
-@st.cache
-def chart_data():
-    chart_data = load_data("SELECT * FROM ufc_table")
-    return chart_data
-
-
-chart_df = chart_data()
+chart_df = load_data("SELECT * FROM ufc_table")
 
 # Win Rate By Charts
 if win_rate_by == "Age":

--- a/streamlit/main.py
+++ b/streamlit/main.py
@@ -305,7 +305,7 @@ if win_rate_by == "Age":
         height=900,
         width=900,
         legend_tracegroupgap=450,
-        legend=dict(title="<b>Age Range (in.):</b> "),
+        legend=dict(title="<b>Age Range:</b> "),
         font=dict(size=18),
     )
     fig.update_traces(marker=dict(line=dict(color="#000000", width=1.25)))

--- a/streamlit/main.py
+++ b/streamlit/main.py
@@ -231,19 +231,19 @@ elif data_selection == "Fighter vs. Fighter":
     # )
 
     # Display statistics of selected fighter.
-    #col1, col2 = st.columns(2)
-    #col1.subheader(f"{blue_name}")
-    #col1.write(f"Age: {blue_age}")
-    #col1.write(f"Height: {blue_height}")
-    #col1.write(f"Weight: {blue_weight}")
-    #col1.write(f"Reach: {blue_reach}")
-    #col1.write(f"Stance: {blue_stance}")
-    #col2.subheader(f"{red_name}")
-    #col2.write(f"Age: {red_age}")
-    #col2.write(f"Height: {red_height}")
-    #col2.write(f"Weight: {red_weight}")
-    #col2.write(f"Reach: {red_reach}")
-    #col2.write(f"Stance: {red_stance}")
+    # col1, col2 = st.columns(2)
+    # col1.subheader(f"{blue_name}")
+    # col1.write(f"Age: {blue_age}")
+    # col1.write(f"Height: {blue_height}")
+    # col1.write(f"Weight: {blue_weight}")
+    # col1.write(f"Reach: {blue_reach}")
+    # col1.write(f"Stance: {blue_stance}")
+    # col2.subheader(f"{red_name}")
+    # col2.write(f"Age: {red_age}")
+    # col2.write(f"Height: {red_height}")
+    # col2.write(f"Weight: {red_weight}")
+    # col2.write(f"Reach: {red_reach}")
+    # col2.write(f"Stance: {red_stance}")
 
 elif data_selection == "Create your own fighter":
     st.subheader("Create your own fighter")
@@ -254,8 +254,9 @@ elif data_selection == "Create your own fighter":
 
 @st.cache
 def chart_data():
-    chart_data = load_data('SELECT * FROM ufc_table')
+    chart_data = load_data("SELECT * FROM ufc_table")
     return chart_data
+
 
 chart_df = chart_data()
 
@@ -263,91 +264,151 @@ chart_df = chart_data()
 if win_rate_by == "Age":
     st.header(f"Win Rate By {win_rate_by}")
 
-    blue_wr_age = chart_df[chart_df.Winner == "Blue"].groupby("B_Age_Bucket").Winner.count().reset_index()
-    red_wr_age = chart_df[chart_df.Winner == "Red"].groupby("R_Age_Bucket").Winner.count().reset_index()
+    blue_wr_age = (
+        chart_df[chart_df.Winner == "Blue"]
+        .groupby("B_Age_Bucket")
+        .Winner.count()
+        .reset_index()
+    )
+    red_wr_age = (
+        chart_df[chart_df.Winner == "Red"]
+        .groupby("R_Age_Bucket")
+        .Winner.count()
+        .reset_index()
+    )
 
     fig = make_subplots(rows=2, cols=1, specs=[[{"type": "pie"}], [{"type": "pie"}]])
 
-    fig.add_trace(go.Pie(
-        values=red_wr_age["Winner"],
-        labels=red_wr_age["R_Age_Bucket"],
-        name="Red Corner",
-        legendgroup='1',
-        title="<b>Red Win Rate By Age</b>"),
-        row=1, col=1)
+    fig.add_trace(
+        go.Pie(
+            values=red_wr_age["Winner"],
+            labels=red_wr_age["R_Age_Bucket"],
+            name="Red Corner",
+            legendgroup="1",
+            title="<b>Red Win Rate By Age</b>",
+        ),
+        row=1,
+        col=1,
+    )
 
-    fig.add_trace(go.Pie(
-        values=blue_wr_age["Winner"],
-        labels=blue_wr_age["B_Age_Bucket"],
-        name="Blue Corner",
-        legendgroup='2',
-        showlegend=True,
-        title="<b>Blue Win Rate By Age</b>"),
-        row=2, col=1)
+    fig.add_trace(
+        go.Pie(
+            values=blue_wr_age["Winner"],
+            labels=blue_wr_age["B_Age_Bucket"],
+            name="Blue Corner",
+            legendgroup="2",
+            showlegend=True,
+            title="<b>Blue Win Rate By Age</b>",
+        ),
+        row=2,
+        col=1,
+    )
 
-    fig.update_layout(margin=dict(l=0, r=500, t=100, b=0),
-                      height=900,
-                      width=900,
-                      legend_tracegroupgap=450,
-                      legend=dict(title="<b>Age Range (in.):</b> "),
-                      font=dict(size=18)
-                      )
-    fig.update_traces(marker=dict(line=dict(color='#000000', width=1.25)))
+    fig.update_layout(
+        margin=dict(l=0, r=500, t=100, b=0),
+        height=900,
+        width=900,
+        legend_tracegroupgap=450,
+        legend=dict(title="<b>Age Range (in.):</b> "),
+        font=dict(size=18),
+    )
+    fig.update_traces(marker=dict(line=dict(color="#000000", width=1.25)))
     st.plotly_chart(fig)
 
 
 elif win_rate_by == "Height":
     st.header(f"Win Rate By {win_rate_by}")
-    blue_wr_height = chart_df[chart_df.Winner == "Blue"].groupby("B_Height_Bucket").Winner.count().reset_index()
-    red_wr_height = chart_df[chart_df.Winner == "Red"].groupby("R_Height_Bucket").Winner.count().reset_index()
+    blue_wr_height = (
+        chart_df[chart_df.Winner == "Blue"]
+        .groupby("B_Height_Bucket")
+        .Winner.count()
+        .reset_index()
+    )
+    red_wr_height = (
+        chart_df[chart_df.Winner == "Red"]
+        .groupby("R_Height_Bucket")
+        .Winner.count()
+        .reset_index()
+    )
 
     fig = make_subplots(rows=2, cols=1, specs=[[{"type": "pie"}], [{"type": "pie"}]])
-    fig.add_trace(go.Pie(
-        values=red_wr_height["Winner"],
-        name="Red Corner",
-        labels=red_wr_height["R_Height_Bucket"],
-        title="<b>Red Win Rate By Height</b>"),
-        row=1, col=1)
-    fig.add_trace(go.Pie(
-        values=blue_wr_height["Winner"],
-        name="Blue Corner",
-        labels=blue_wr_height["B_Height_Bucket"],
-        title="<b>Blue Win Rate By Height</b>"),
-        row=2, col=1)
-    fig.update_layout(margin=dict(l=0, r=500, t=100, b=0),
-                      height=900,
-                      width=900,
-                      legend=dict(title="<b>Height Range (in.):</b> "),
-                      font_size=18)
-    fig.update_traces(marker=dict(line=dict(color='#000000', width=1.25)))
+    fig.add_trace(
+        go.Pie(
+            values=red_wr_height["Winner"],
+            name="Red Corner",
+            labels=red_wr_height["R_Height_Bucket"],
+            title="<b>Red Win Rate By Height</b>",
+        ),
+        row=1,
+        col=1,
+    )
+    fig.add_trace(
+        go.Pie(
+            values=blue_wr_height["Winner"],
+            name="Blue Corner",
+            labels=blue_wr_height["B_Height_Bucket"],
+            title="<b>Blue Win Rate By Height</b>",
+        ),
+        row=2,
+        col=1,
+    )
+    fig.update_layout(
+        margin=dict(l=0, r=500, t=100, b=0),
+        height=900,
+        width=900,
+        legend=dict(title="<b>Height Range (in.):</b> "),
+        font_size=18,
+    )
+    fig.update_traces(marker=dict(line=dict(color="#000000", width=1.25)))
     st.plotly_chart(fig)
 
 elif win_rate_by == "Weight Class":
     st.header(f"Win Rate By {win_rate_by}")
-    blue_wr_weight = chart_df[chart_df.Winner == "Blue"].groupby("Weight_Class").Winner.count().reset_index()
-    red_wr_weight = chart_df[chart_df.Winner == "Red"].groupby("Weight_Class").Winner.count().reset_index()
+    blue_wr_weight = (
+        chart_df[chart_df.Winner == "Blue"]
+        .groupby("Weight_Class")
+        .Winner.count()
+        .reset_index()
+    )
+    red_wr_weight = (
+        chart_df[chart_df.Winner == "Red"]
+        .groupby("Weight_Class")
+        .Winner.count()
+        .reset_index()
+    )
 
     fig = make_subplots(rows=2, cols=1, specs=[[{"type": "pie"}], [{"type": "pie"}]])
-    fig.add_trace(go.Pie(
-        values=red_wr_weight["Winner"],
-        labels=red_wr_weight["Weight_Class"],
-        name="Red Corner",
-        title="<b>Red Win Rate By Weight Class</b>"),
-        row=1, col=1)
+    fig.add_trace(
+        go.Pie(
+            values=red_wr_weight["Winner"],
+            labels=red_wr_weight["Weight_Class"],
+            name="Red Corner",
+            title="<b>Red Win Rate By Weight Class</b>",
+        ),
+        row=1,
+        col=1,
+    )
 
-    fig.add_trace(go.Pie(
-        values=blue_wr_weight["Winner"],
-        labels=blue_wr_weight["Weight_Class"],
-        name="Blue Corner",
-        title="<b>Blue Win Rate By Weight Class</b>"),
-        row=2, col=1)
+    fig.add_trace(
+        go.Pie(
+            values=blue_wr_weight["Winner"],
+            labels=blue_wr_weight["Weight_Class"],
+            name="Blue Corner",
+            title="<b>Blue Win Rate By Weight Class</b>",
+        ),
+        row=2,
+        col=1,
+    )
 
-    fig.update_layout(margin=dict(l=0, r=500, t=100, b=0),
-                      height=900,
-                      width=900,
-                      legend=dict(title="<b>Weight Classes:</b> ",x=1.1),
-                      font=dict(size=18), legend_font_size=18)
-    fig.update_traces(marker=dict(line=dict(color='#000000', width=.5)))
+    fig.update_layout(
+        margin=dict(l=0, r=500, t=100, b=0),
+        height=900,
+        width=900,
+        legend=dict(title="<b>Weight Classes:</b> ", x=1.1),
+        font=dict(size=18),
+        legend_font_size=18,
+    )
+    fig.update_traces(marker=dict(line=dict(color="#000000", width=0.5)))
     st.plotly_chart(fig)
 
 elif win_rate_by == "Stance":
@@ -356,33 +417,49 @@ elif win_rate_by == "Stance":
 
     fig = make_subplots(rows=2, cols=1, specs=[[{"type": "pie"}], [{"type": "pie"}]])
 
-    blue_wr_stance = chart_df[chart_df.Winner == "Blue"].groupby("B_Stance").Winner.count().reset_index()
-    red_wr_stance = chart_df[chart_df.Winner == "Red"].groupby("R_Stance").Winner.count().reset_index()
-    fig.append_trace(go.Pie(
-        values=red_wr_stance["Winner"],
-        labels=red_wr_stance["R_Stance"],
-        name="Red Corner",
-        title="<b>Red Win Rate By Stance</b>"),
-        row=1, col=1)
+    blue_wr_stance = (
+        chart_df[chart_df.Winner == "Blue"]
+        .groupby("B_Stance")
+        .Winner.count()
+        .reset_index()
+    )
+    red_wr_stance = (
+        chart_df[chart_df.Winner == "Red"]
+        .groupby("R_Stance")
+        .Winner.count()
+        .reset_index()
+    )
+    fig.append_trace(
+        go.Pie(
+            values=red_wr_stance["Winner"],
+            labels=red_wr_stance["R_Stance"],
+            name="Red Corner",
+            title="<b>Red Win Rate By Stance</b>",
+        ),
+        row=1,
+        col=1,
+    )
 
-    fig.append_trace(go.Pie(
-        values=blue_wr_stance["Winner"],
-        labels=blue_wr_stance["B_Stance"],
-        name="Blue Corner",
-        title="<b>Blue Win Rate By Stance</b>"),
-        row=2, col=1)
+    fig.append_trace(
+        go.Pie(
+            values=blue_wr_stance["Winner"],
+            labels=blue_wr_stance["B_Stance"],
+            name="Blue Corner",
+            title="<b>Blue Win Rate By Stance</b>",
+        ),
+        row=2,
+        col=1,
+    )
 
-    fig.update_layout(margin=dict(l=0, r=500, t=100, b=0),
-                      height=900,
-                      width=900,
-                      legend=dict(title="<b>Fight Stance:</b> "),
-                      font=dict(size=18)
-                      )
-    fig.update_traces(marker=dict(line=dict(color='#000000', width=1.25)))
+    fig.update_layout(
+        margin=dict(l=0, r=500, t=100, b=0),
+        height=900,
+        width=900,
+        legend=dict(title="<b>Fight Stance:</b> "),
+        font=dict(size=18),
+    )
+    fig.update_traces(marker=dict(line=dict(color="#000000", width=1.25)))
     st.plotly_chart(fig)
-
-
-
 
 
 # # Check if the original dataframe has the same results as database.

--- a/streamlit/main.py
+++ b/streamlit/main.py
@@ -51,6 +51,9 @@ def create_fight_matchup(df):
 ufc_df = load_data()
 ufc_df = create_fight_matchup(ufc_df)
 
+chart_df = load_data(
+    'SELECT "R_Age_Bucket", "B_Age_Bucket", "B_Height_Bucket", "R_Height_Bucket", "B_Stance", "R_Stance", "Weight_Class", "Winner" FROM ufc_table'
+)
 # Load Model
 clf = load_model()
 
@@ -251,15 +254,11 @@ elif data_selection == "Create your own fighter":
     # TODO: Display probability of prediction.
     # TODO: Display statistics of selected fighter.
 
-
-chart_df = load_data(
-    'SELECT "R_Age_Bucket", "B_Age_Bucket", "B_Height_Bucket", "R_Height_Bucket", "B_Stance", "R_Stance", "Weight_Class", "Winner" FROM ufc_table'
-)
-
-# Win Rate By Charts
+# Pie Charts
+# ----- #
+# `Win Rate By` Charts
 if win_rate_by == "Age":
     st.header(f"Win Rate By {win_rate_by}")
-
     blue_wr_age = (
         chart_df[chart_df.Winner == "Blue"]
         .groupby("B_Age_Bucket")

--- a/streamlit/main.py
+++ b/streamlit/main.py
@@ -252,7 +252,9 @@ elif data_selection == "Create your own fighter":
     # TODO: Display statistics of selected fighter.
 
 
-chart_df = load_data("SELECT * FROM ufc_table")
+chart_df = load_data(
+    'SELECT "R_Age_Bucket", "B_Age_Bucket", "B_Height_Bucket", "R_Height_Bucket", "B_Stance", "R_Stance", "Weight_Class", "Winner" FROM ufc_table'
+)
 
 # Win Rate By Charts
 if win_rate_by == "Age":


### PR DESCRIPTION
Enhancements towards #97 

[DASHBOARD: Formatted code for consistency](https://github.com/seven-foot-two/turtle-time/commit/775903488eb43783cc6432066e34e0d3473fb535)
- Opinionated formatting changes

[DASHBOARD: Removal of unnecessary function](https://github.com/seven-foot-two/turtle-time/commit/2002609c978e158b3f1071c627c9742f86ac0bf5)
- I do not believe `def chart_data()` is needed since the parameters can be called by `load_data()` directly
- Also, I do not believe the data should be cached forever assuming our data will be constantly changing

[DASHBOARD: Reduced chart_df query time](https://github.com/seven-foot-two/turtle-time/commit/17aea3a399b927be87e671ec4d2473a2cc1e932a)
- I changed the query SELECT from using * to select every column to only the needed columns
- Reduces the query time from ~20 seconds to ~2 seconds

**Before**
```sql
SELECT * FROM ufc_table
```
![before_sql](https://user-images.githubusercontent.com/40713017/161196560-3179cfe9-6a79-4b05-8790-5c234ee67712.png)

**After**
```sql
SELECT "R_Age_Bucket", "B_Age_Bucket", "B_Height_Bucket", "R_Height_Bucket", "B_Stance", "R_Stance", "Weight_Class", "Winner" FROM ufc_table
```
![after_sql](https://user-images.githubusercontent.com/40713017/161196613-b99b496f-db7d-4a7a-8c3c-25c1fd52697c.png)

[DASHBOARD: Fixed typo in age pie chart legend](https://github.com/seven-foot-two/turtle-time/commit/701d9129749a06bdab3d1245608a4f67c3cb0565)
- I removed inches from the legend of the age pie chart

[DASHBOARD: Rearranged chart_df](https://github.com/seven-foot-two/turtle-time/commit/a214fa5f68c050906790e833dc23851f3798ef0d)
- Opinionated formatting changes