### PR TITLE
Matin

### DIFF
--- a/UFC_Final_Project.ipynb
+++ b/UFC_Final_Project.ipynb
@@ -1217,6 +1217,17 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "2327f0c3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fighter_agg_stats.columns = fighter_agg_stats.columns.str.strip(\"B_\")\n",
+    "fighter_agg_stats.head()\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "aacd7ae1",
    "metadata": {},
    "outputs": [],

--- a/UFC_Final_Project.ipynb
+++ b/UFC_Final_Project.ipynb
@@ -21,7 +21,7 @@
     "import os\n",
     "import numpy as np\n",
     "import psycopg2\n",
-    "#from config import password\n",
+    "from config import password\n",
     "from sqlalchemy import create_engine\n",
     "import io\n"
    ]
@@ -1104,7 +1104,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# creates dataframe of only Red aggregate fighter stats\n",
+    "# creates dataframe of only Blue aggregate fighter stats\n",
     "agg_stats_B_df  = fighter_stats_df[\n",
     "        [\n",
     "        \"Event_Date\",\n",
@@ -1169,7 +1169,7 @@
     "        \"R_Height_Bucket\": \"B_Height_Bucket\",\n",
     "        \"R_Age\":\"B_Age\",\n",
     "        \"R_Height\":\"B_Height\",\n",
-    "        \"R_Weight\":\"B_Heights\",\n",
+    "        \"R_Weight\":\"B_Weight\",\n",
     "        \"R_Reach\":\"B_Reach\",\n",
     "        \"R_Wins\":\"B_Wins\",\n",
     "        \"R_Losses\":\"B_Losses\",\n",
@@ -1545,16 +1545,6 @@
     "]\n",
     "\n",
     "fight_stats_df.shape\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "7b3b75e4",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "all_stats_df.head()"
    ]
   },
   {


### PR DESCRIPTION
Fixed some typos in #93 

### [Fix of code typos in UFC_Final_Project.ipynb](https://github.com/seven-foot-two/turtle-time/commit/b89ac0b0fef9e662d412fbdfbfb54bb5e6f53e6f)
**Before** 
```python
"R_Weight":"B_Heights"
```
**After**
```python
"R_Weight":"B_Weight"
```

The other change was the typo in the comment: 
```python
# creates dataframe of only Red aggregate fighter stats
agg_stats_B_df  = fighter_stats_df[
        [
        "Event_Date",
        "B_Name",
        "B_Stance",
        "B_Age_Bucket",
        "B_Height_Bucket",
        "B_Age",
        "B_Height",
        "B_Weight",
        "B_Reach",
        "B_Wins",
        "B_Losses",
        "B_Draws",
        "B_No_Contest",
        "B_Career_Significant_Strikes_Landed_PM",
        "B_Career_Striking_Accuracy",
        "B_Career_Significant_Strike_Defence",
        "B_Career_Takedown_Average",
        "B_Career_Takedown_Accuracy",
        "B_Career_Takedown_Defence",
        "B_Career_Submission_Average",
        "B_Knockdowns"
        ]
]
```
And, removing the `all_stats_df.head()`

### [Remove prefix from aggregated fighter data](https://github.com/seven-foot-two/turtle-time/commit/3e4138887d6d35a73f4c76b3bf9f422ff9a140ba)
- I removed `B_` prefix from the columns

New table structure for `fighter_agg_stats`

| **Field name**                       | **Type**  | **Array?** | **Allow nulls?** |
|--------------------------------------|-----------|------------|------------------|
| Event_Date                           | timestamp | No         | Yes              |
| Name                                 | text      | No         | Yes              |
| Stance                               | text      | No         | Yes              |
| Age_Bucket                           | text      | No         | Yes              |
| Height_Bucket                        | text      | No         | Yes              |
| Age                                  | int8      | No         | Yes              |
| Height                               | int8      | No         | Yes              |
| Weight                               | int8      | No         | Yes              |
| Reach                                | int8      | No         | Yes              |
| Wins                                 | int8      | No         | Yes              |
| Losses                               | int8      | No         | Yes              |
| Draws                                | int8      | No         | Yes              |
| No_Contest                           | int8      | No         | Yes              |
| Career_Significant_Strikes_Landed_PM | float8    | No         | Yes              |
| Career_Striking_Accuracy             | int8      | No         | Yes              |
| Career_Significant_Strike_Defence    | int8      | No         | Yes              |
| Career_Takedown_Average              | float8    | No         | Yes              |
| Career_Takedown_Accuracy             | int8      | No         | Yes              |
| Career_Takedown_Defence              | int8      | No         | Yes              |
| Career_Submission_Average            | float8    | No         | Yes              |
| Knockdowns                           | int8      | No         | Yes              |

